### PR TITLE
fix(ui): dashboard content overflowed layout

### DIFF
--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -3,7 +3,7 @@ import {Container} from '@sanity/ui'
 
 export function DashboardLayout(props: PropsWithChildren<{}>) {
   return (
-    <Container width={4} padding={4} sizing="border" style={{minHeight: '100%'}}>
+    <Container width={4} padding={4} sizing="border" style={{height: '100%', overflowY: 'auto'}}>
       {props.children}
     </Container>
   )


### PR DESCRIPTION
Currently, if the dashboard height exceeds the height of the application frame, then the content will break outside of the studio layout. 

The issue is obvious in my NextJS embedded studio when in dark mode and the body background is white as demonstrated below:

<img width="1512" alt="Screenshot 2022-12-01 at 23 11 47" src="https://user-images.githubusercontent.com/1453384/205074516-9f771f6e-5f10-48bb-8993-21e4b4f97076.png">
