### PR TITLE
feat: list all studios from user applications list

### DIFF
--- a/src/versionedClient.ts
+++ b/src/versionedClient.ts
@@ -1,5 +1,5 @@
 import {useClient} from 'sanity'
 
 export function useVersionedClient() {
-  return useClient({apiVersion: '2024-06-03'})
+  return useClient({apiVersion: '2024-08-01'})
 }

--- a/src/widgets/projectInfo/index.ts
+++ b/src/widgets/projectInfo/index.ts
@@ -1,5 +1,5 @@
 import {ProjectInfo} from './ProjectInfo'
-import {LayoutConfig, DashboardWidget} from '../../types'
+import {type LayoutConfig, type DashboardWidget} from '../../types'
 
 export function projectInfoWidget(config?: {layout?: LayoutConfig}): DashboardWidget {
   return {

--- a/src/widgets/projectInfo/types.ts
+++ b/src/widgets/projectInfo/types.ts
@@ -1,0 +1,28 @@
+import {type DashboardWidget} from '../../types'
+
+export interface ProjectInfoProps {
+  __experimental_before?: DashboardWidget[]
+  data: ProjectData[]
+}
+
+export interface App {
+  title: string
+  rows?: App[]
+  value?: string | {error: string}
+}
+
+export interface ProjectData {
+  title: string
+  category?: string
+}
+
+export interface UserApplication {
+  id: string
+  projectId: string
+  title: string | null
+  type: string
+  urlType: 'internal' | 'external'
+  appHost: string
+
+  // … there are other props here, but we don't really care about them for our use case
+}


### PR DESCRIPTION
Uses the new user applications endpoint instead of relying on `studioHost`/`externalStudioHost`, which no longer tells the full story.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/e559d4a4-45e8-481f-b8f1-b8fd7ccea406">
