### PR TITLE
fix(deps): allow studio v4 in peer dep ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
       },
       "peerDependencies": {
         "react": "^18 || >=19.0.0-0",
-        "sanity": "^3",
+        "sanity": "^3 || ^4.0.0-0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "peerDependencies": {
     "react": "^18 || >=19.0.0-0",
-    "sanity": "^3",
+    "sanity": "^3 || ^4.0.0-0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description

Prepping for July 15th: https://www.sanity.io/blog/a-major-version-bump-for-a-minor-reason#299526b398ec

Currently when using a package.json like: 
```json
{
  "dependencies": {
    "sanity": "4.0.0-0"
  }
}
```
Running `pnpm install --resolution-only` yields peer dep issues:
```bash
pnpm install --resolution-only
WARN Issues with peer dependencies found
.
└─┬ @sanity/dashboard 4.1.3
  └── ✕ unmet peer sanity@^3: found 4.0.0-0
Done in 10s using pnpm v10.12.1
```
This fixes it.

### Testing

Tested locally
